### PR TITLE
Allow pluigin to be used with apps compiled with Sencha Cmd

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -68,6 +68,12 @@ This accepts a route handler URI path, such as C</api>. You can also use Dancer
 wildcards such as C</projects/*/api>, so that the values caught are passed to 
 your method handlers.
 
+=item B<variable>
+
+This accepts a variable name to store the remoting configuration in, such as 
+C<REMOTING_API>. You will need to use this if your app is compiled with Sencha 
+Cmd.
+
 =item B<namespace>
 
 This option is injected to the addProvider method call.

--- a/lib/Dancer/Plugin/ExtDirect.pm
+++ b/lib/Dancer/Plugin/ExtDirect.pm
@@ -32,16 +32,19 @@ register extdirect => sub ($) {
                 };
             }
         }
-        
         content_type 'text/javascript';
-        sprintf "Ext.Direct.addProvider(%s);\n",
-            to_json {
-                url       => request->path . '/router',
-                type      => 'remoting',
-                actions   => $actions,
-                $init->{namespace} ? (namespace => $init->{namespace}) : (),
-                $init->{provider_config} ? %{$init->{provider_config}} : (),
-            };
+        my $api_string = to_json {
+            url       => request->path . '/router',
+            type      => 'remoting',
+            actions   => $actions,
+            $init->{namespace} ? (namespace => $init->{namespace}) : (),
+            $init->{provider_config} ? %{$init->{provider_config}} : (),
+        };
+        if (defined($init->{variable})) {
+            sprintf "%s = %s;\n", $init->{variable}, $api_string;
+        } else {
+            sprintf "Ext.Direct.addProvider(%s);\n", $api_string;
+        }
     };
     
     post $init->{api} . '/router' => sub {


### PR DESCRIPTION
Allow the remoting configuration to be stored in a variable rather than directly constructed.  This is required when using Sencha Cmd to build an app as the api will be loaded before the Ext framework is completely loaded.
